### PR TITLE
Jack No longer need to be

### DIFF
--- a/org.rncbc.qsynth.json
+++ b/org.rncbc.qsynth.json
@@ -28,7 +28,6 @@
     "*.la"
   ],
   "modules": [
-    "shared-modules/linux-audio/jack2.json",
     "shared-modules/linux-audio/libinstpatch.json",
     "shared-modules/linux-audio/fluidsynth2.json",
     {


### PR DESCRIPTION
The header are built into the runtime