### PR TITLE
Allow KDE Plasma tray icon to work

### DIFF
--- a/org.rncbc.qsynth.json
+++ b/org.rncbc.qsynth.json
@@ -20,7 +20,9 @@
     /* Allow other instances to see lockfiles */
     "--env=TMPDIR=/var/tmp",
     /* On SuSE it seems to be necessary for sound to work */
-    "--env=ALSA_CONFIG_PATH="
+    "--env=ALSA_CONFIG_PATH=",
+    /* Allow KDE Plasma tray icon to work */
+    "--talk-name=org.kde.StatusNotifierWatcher"
   ],
   "cleanup": [
     "/share/man",


### PR DESCRIPTION
This change should allow Qsynth's system tray settings and functionality to work correctly. Currently the related options are greyed-out in the Flatpak version of Qsynth.